### PR TITLE
Add benchmarking for dig, fetch chaining, and dig_fetch

### DIFF
--- a/benchmark/jvc_me_benchmark_3.rb
+++ b/benchmark/jvc_me_benchmark_3.rb
@@ -1,0 +1,25 @@
+require 'benchmark/ips'
+
+thing = {
+    :foo => {
+        :bar => {       
+            :foobar => "foobar"
+        }
+    }
+}
+
+Benchmark.ips do |x|
+  x.iterations = 3
+
+  x.report("digging") do
+    thing.dig(:foo, :bar, :foobar)
+  end
+
+  x.report("fetch chaining") do
+    thing.fetch(:foo).fetch(:bar).fetch(:foobar)
+  end
+
+  x.report("dig fetching") do
+    thing.dig_fetch(:foo, :bar, :foobar)
+  end
+end

--- a/benchmark/jvc_me_benchmark_6.rb
+++ b/benchmark/jvc_me_benchmark_6.rb
@@ -1,0 +1,31 @@
+require 'benchmark/ips'
+
+thing = {
+    :foo => {
+        :bar => {
+            :foobar => {
+                :foo => {
+                    :bar => {
+                        :foobar => "foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+
+Benchmark.ips do |x|
+  x.iterations = 3
+
+  x.report("digging") do
+    thing.dig(:foo, :bar, :foobar, :foo, :bar, :foobar)
+  end
+
+  x.report("fetch chaining") do
+    thing.fetch(:foo).fetch(:bar).fetch(:foobar).fetch(:foo).fetch(:bar).fetch(:foobar)
+  end
+
+  x.report("dig fetching") do
+    thing.dig_fetch(:foo, :bar, :foobar, :foo, :bar, :foobar)
+  end
+end

--- a/benchmark/jvc_me_benchmark_9.rb
+++ b/benchmark/jvc_me_benchmark_9.rb
@@ -1,0 +1,37 @@
+require 'benchmark/ips'
+
+thing = {
+    :foo => {
+        :bar => {
+            :foobar => {
+                :foo => {
+                    :bar => {
+                        :foobar => {
+                            :foo => {
+                                :bar => {
+                                    :foobar => "foobar"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+Benchmark.ips do |x|
+  x.iterations = 3
+
+  x.report("digging") do
+    thing.dig(:foo, :bar, :foobar, :foo, :bar, :foobar, :foo, :bar, :foobar)
+  end
+
+  x.report("fetch chaining") do
+    thing.fetch(:foo).fetch(:bar).fetch(:foobar).fetch(:foo).fetch(:bar).fetch(:foobar).fetch(:foo).fetch(:bar).fetch(:foobar)
+  end
+
+  x.report("dig fetching") do
+    thing.dig_fetch(:foo, :bar, :foobar, :foo, :bar, :foobar, :foo, :bar, :foobar)
+  end
+end

--- a/benchmark/mri_benchmark_3.rb
+++ b/benchmark/mri_benchmark_3.rb
@@ -1,0 +1,21 @@
+require 'benchmark/ips'
+
+thing = {
+    :foo => {
+        :bar => {       
+            :foobar => "foobar"
+        }
+    }
+}
+
+Benchmark.ips do |x|
+  x.iterations = 3
+
+  x.report("digging") do
+    thing.dig(:foo, :bar, :foobar)
+  end
+
+  x.report("fetch chaining") do
+    thing.fetch(:foo).fetch(:bar).fetch(:foobar)
+  end
+end

--- a/benchmark/mri_benchmark_6.rb
+++ b/benchmark/mri_benchmark_6.rb
@@ -1,0 +1,27 @@
+require 'benchmark/ips'
+
+thing = {
+    :foo => {
+        :bar => {
+            :foobar => {
+                :foo => {
+                    :bar => {
+                        :foobar => "foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+
+Benchmark.ips do |x|
+  x.iterations = 3
+
+  x.report("digging") do
+    thing.dig(:foo, :bar, :foobar, :foo, :bar, :foobar)
+  end
+
+  x.report("fetch chaining") do
+    thing.fetch(:foo).fetch(:bar).fetch(:foobar).fetch(:foo).fetch(:bar).fetch(:foobar)
+  end
+end

--- a/benchmark/mri_benchmark_9.rb
+++ b/benchmark/mri_benchmark_9.rb
@@ -1,0 +1,33 @@
+require 'benchmark/ips'
+
+thing = {
+    :foo => {
+        :bar => {
+            :foobar => {
+                :foo => {
+                    :bar => {
+                        :foobar => {
+                            :foo => {
+                                :bar => {
+                                    :foobar => "foobar"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+Benchmark.ips do |x|
+  x.iterations = 3
+
+  x.report("digging") do
+    thing.dig(:foo, :bar, :foobar, :foo, :bar, :foobar, :foo, :bar, :foobar)
+  end
+
+  x.report("fetch chaining") do
+    thing.fetch(:foo).fetch(:bar).fetch(:foobar).fetch(:foo).fetch(:bar).fetch(:foobar).fetch(:foo).fetch(:bar).fetch(:foobar)
+  end
+end


### PR DESCRIPTION
TODO: Provide overview

Currently this is a set of benchmarks to test performance of the implementation of `dig_fetch` in TruffleRuby [here](https://github.com/jantnovi/truffleruby/pull/1).